### PR TITLE
Add a custom User-Agent for usage measurement

### DIFF
--- a/lib/linodeapi/raw.rb
+++ b/lib/linodeapi/raw.rb
@@ -16,6 +16,7 @@ module LinodeAPI
       @options[:names] ||= []
       @options[:spec] ||= LinodeAPI.spec
       @options[:apikey] ||= authenticate(params)
+      @options[:user_agent_prefix] ||= ''
     end
 
     def respond_to_missing?(method, include_private = false)
@@ -89,7 +90,12 @@ module LinodeAPI
     end
 
     def user_agent
-      "linodeapi/#{LinodeAPI::VERSION} ruby/#{RUBY_VERSION}"
+      user_agent_fragments = [
+        @options[:user_agent_prefix],
+        "linodeapi/#{LinodeAPI::VERSION}",
+        "ruby/#{RUBY_VERSION}"
+      ]
+      user_agent_fragments.reject(&:empty?).join(' ')
     end
 
     def build_call_body(method, params)

--- a/lib/linodeapi/raw.rb
+++ b/lib/linodeapi/raw.rb
@@ -82,8 +82,14 @@ module LinodeAPI
     def call(method, params = {})
       options = build_call_body(method, params)
       self.class.error_check self.class.post(
-        '', body: options, base_uri: endpoint
+        '', body: options,
+            base_uri: endpoint,
+            headers: { 'User-Agent' => user_agent }
       )
+    end
+
+    def user_agent
+      "linodeapi/#{LinodeAPI::VERSION}"
     end
 
     def build_call_body(method, params)

--- a/lib/linodeapi/raw.rb
+++ b/lib/linodeapi/raw.rb
@@ -89,7 +89,7 @@ module LinodeAPI
     end
 
     def user_agent
-      "linodeapi/#{LinodeAPI::VERSION}"
+      "linodeapi/#{LinodeAPI::VERSION} ruby/#{RUBY_VERSION}"
     end
 
     def build_call_body(method, params)

--- a/lib/linodeapi/version.rb
+++ b/lib/linodeapi/version.rb
@@ -1,0 +1,3 @@
+module LinodeAPI
+  VERSION = '2.0.2'.freeze
+end

--- a/linodeapi.gemspec
+++ b/linodeapi.gemspec
@@ -1,6 +1,11 @@
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'linodeapi/version'
+
 Gem::Specification.new do |s|
   s.name        = 'linodeapi'
-  s.version     = '2.0.1'
+  s.version     = LinodeAPI::VERSION
   s.date        = Time.now.strftime('%Y-%m-%d')
 
   s.summary     = 'Linode API wrapper'


### PR DESCRIPTION
The default `User-Agent` for `Net::HTTP` is `Ruby`, so usage
metrics for this gem blend in with all other Ruby code that
is interacting with the Linode API and not setting a custom
value for the `User-Agent` header.

Setting a custom `User-Agent` that includes the gem name and
version will make it easier to get accurate usage metrics as
we move forward.